### PR TITLE
Fo 1308 konsolfeilmeldinger normaltekst

### DIFF
--- a/src/app/visningskomponenter/felles-komponenter/normaltekstwrapper.tsx
+++ b/src/app/visningskomponenter/felles-komponenter/normaltekstwrapper.tsx
@@ -1,0 +1,24 @@
+import { Normaltekst } from 'nav-frontend-typografi';
+import * as React from 'react';
+
+import { isNullOrUndefined } from '../../utils/util';
+import { StringOrNothing } from '../felles-typer';
+
+interface Props {
+    value?: StringOrNothing;
+    label?: StringOrNothing;
+}
+
+function NormalTekstWrapper(props: Props) {
+    if (isNullOrUndefined(props.value)) {
+        return null;
+    }
+
+    const { value, label } = props;
+
+    return (
+            <Normaltekst>{label}{value}</Normaltekst>
+    );
+}
+
+export default NormalTekstWrapper;

--- a/src/app/visningskomponenter/felles-komponenter/normaltekstwrapper.tsx
+++ b/src/app/visningskomponenter/felles-komponenter/normaltekstwrapper.tsx
@@ -1,24 +1,19 @@
-import { Normaltekst } from 'nav-frontend-typografi';
+import Normaltekst from "nav-frontend-typografi/lib/normaltekst";
 import * as React from 'react';
 
-import { isNullOrUndefined } from '../../utils/util';
-import { StringOrNothing } from '../felles-typer';
-
-interface Props {
-    value?: StringOrNothing;
-    label?: StringOrNothing;
+interface ChildProps {
+    children?: React.ReactNode
 }
 
-function NormalTekstWrapper(props: Props) {
-    if (isNullOrUndefined(props.value)) {
-        return null;
+function notNullChildren<T>(Comp: React.ComponentType<T & ChildProps>) {
+    return (props: T & ChildProps) => {
+        if (!props.children) {
+            return null;
+        }
+        return <Comp {...props}/>;
     }
-
-    const { value, label } = props;
-
-    return (
-            <Normaltekst>{label}{value}</Normaltekst>
-    );
 }
+
+const NormalTekstWrapper = notNullChildren(Normaltekst);
 
 export default NormalTekstWrapper;

--- a/src/app/visningskomponenter/personalia/adresser.tsx
+++ b/src/app/visningskomponenter/personalia/adresser.tsx
@@ -2,6 +2,7 @@ import { Element, Normaltekst } from 'nav-frontend-typografi';
 import * as React from 'react';
 import {PersonaliaBostedsadresse, PersonaliaInfo} from "../../datatyper/personalia";
 import {isNullOrUndefined} from "../../utils/util";
+import NormalTekstWrapper from "../felles-komponenter/normaltekstwrapper";
 
 function SammensattFolkeregistrertAdresse(props: Pick<PersonaliaInfo, 'bostedsadresse'>) {
     if (isNullOrUndefined(props.bostedsadresse)) {
@@ -28,11 +29,11 @@ function PostAdresse(props: Pick<PersonaliaInfo, 'postAdresse'>) {
     return (
         <div className="underinformasjon">
             <Element> Postadresse </Element>
-            { adresselinje1 && <Normaltekst> {adresselinje1} </Normaltekst> }
-            { adresselinje2 && <Normaltekst> {adresselinje2} </Normaltekst> }
-            { adresselinje3 && <Normaltekst> {adresselinje3} </Normaltekst> }
-            { adresselinje4 && <Normaltekst> {adresselinje4} </Normaltekst> }
-            { landkode && <Normaltekst> {landkode} </Normaltekst> }
+            <NormalTekstWrapper value={adresselinje1} />
+            <NormalTekstWrapper value={adresselinje2} />
+            <NormalTekstWrapper value={adresselinje3} />
+            <NormalTekstWrapper value={adresselinje4} />
+            <NormalTekstWrapper value={landkode} />
         </div>
     );
 }

--- a/src/app/visningskomponenter/personalia/adresser.tsx
+++ b/src/app/visningskomponenter/personalia/adresser.tsx
@@ -28,9 +28,9 @@ function PostAdresse(props: Pick<PersonaliaInfo, 'postAdresse'>) {
     return (
         <div className="underinformasjon">
             <Element> Postadresse </Element>
-            { adresselinje1 && <span> {adresselinje1} </span> }
-            { adresselinje2 && <span> {adresselinje2} </span> }
-            { adresselinje3 && <span> {adresselinje3} </span> }
+            { adresselinje1 && <Normaltekst> {adresselinje1} </Normaltekst> }
+            { adresselinje2 && <Normaltekst> {adresselinje2} </Normaltekst> }
+            { adresselinje3 && <Normaltekst> {adresselinje3} </Normaltekst> }
             { adresselinje4 && <Normaltekst> {adresselinje4} </Normaltekst> }
             { landkode && <Normaltekst> {landkode} </Normaltekst> }
         </div>

--- a/src/app/visningskomponenter/personalia/adresser.tsx
+++ b/src/app/visningskomponenter/personalia/adresser.tsx
@@ -29,11 +29,11 @@ function PostAdresse(props: Pick<PersonaliaInfo, 'postAdresse'>) {
     return (
         <div className="underinformasjon">
             <Element> Postadresse </Element>
-            <NormalTekstWrapper value={adresselinje1} />
-            <NormalTekstWrapper value={adresselinje2} />
-            <NormalTekstWrapper value={adresselinje3} />
-            <NormalTekstWrapper value={adresselinje4} />
-            <NormalTekstWrapper value={landkode} />
+            <NormalTekstWrapper> {adresselinje1} </NormalTekstWrapper>
+            <NormalTekstWrapper> {adresselinje2} </NormalTekstWrapper>
+            <NormalTekstWrapper> {adresselinje3} </NormalTekstWrapper>
+            <NormalTekstWrapper> {adresselinje4} </NormalTekstWrapper>
+            <NormalTekstWrapper> {landkode} </NormalTekstWrapper>
         </div>
     );
 }

--- a/src/app/visningskomponenter/personalia/adresser.tsx
+++ b/src/app/visningskomponenter/personalia/adresser.tsx
@@ -27,24 +27,12 @@ function PostAdresse(props: Pick<PersonaliaInfo, 'postAdresse'>) {
 
     return (
         <div className="underinformasjon">
-            <Element>
-                Postadresse
-            </Element>
-            <Normaltekst>
-                {adresselinje1}
-            </Normaltekst>
-            <Normaltekst>
-                {adresselinje2}
-            </Normaltekst>
-            <Normaltekst>
-                {adresselinje3}
-            </Normaltekst>
-            <Normaltekst>
-                {adresselinje4}
-            </Normaltekst>
-            <Normaltekst>
-                {landkode}
-            </Normaltekst>
+            <Element> Postadresse </Element>
+            { adresselinje1 && <span> {adresselinje1} </span> }
+            { adresselinje2 && <span> {adresselinje2} </span> }
+            { adresselinje3 && <span> {adresselinje3} </span> }
+            { adresselinje4 && <Normaltekst> {adresselinje4} </Normaltekst> }
+            { landkode && <Normaltekst> {landkode} </Normaltekst> }
         </div>
     );
 }

--- a/src/app/visningskomponenter/personalia/barn.tsx
+++ b/src/app/visningskomponenter/personalia/barn.tsx
@@ -34,7 +34,7 @@ function Barn(props: Pick<PersonaliaInfo, 'barn'>) {
 
     const { barn, ...rest} = props;
 
-    const barnListe = barn.map((ettBarn) => <EnkeltBarn barn={ettBarn} key={ettBarn.fodselsnummer} />);
+    const barnListe = barn.map((ettBarn, index) => <EnkeltBarn barn={ettBarn} key={index} />);
     return (
         <Informasjonsbolk header="Barn under 21 år" {...rest}>
             {barnListe}

--- a/src/app/visningskomponenter/ytelser/vedtaksliste.tsx
+++ b/src/app/visningskomponenter/ytelser/vedtaksliste.tsx
@@ -27,8 +27,8 @@ function Vedtaksliste(props: Pick<YtelseDataType, 'vedtaksliste'>) {
             <InformasjonsbolkEnkel header="Vedtakstatus" value={visEmdashHvisNull(vedtak.status)} />
             <InformasjonsbolkEnkel header="Aktivitetsfase" value={visEmdashHvisNull(vedtak.aktivitetsfase)} />
             <Informasjonsbolk header="Vedtaksperiode" {...props}>
-                <NormalTekstWrapper label="Fra: " value={formaterDato(vedtak.fradato)} />
-                <NormalTekstWrapper label="Til: " value={formaterDato(vedtak.tildato)} />
+                <NormalTekstWrapper>{vedtak.fradato && `Fra: ${formaterDato(vedtak.fradato)}`}</NormalTekstWrapper>
+                <NormalTekstWrapper>{vedtak.tildato && `Til: ${formaterDato(vedtak.tildato)}`}</NormalTekstWrapper>
             </Informasjonsbolk>
         </Grid>
     ));

--- a/src/app/visningskomponenter/ytelser/vedtaksliste.tsx
+++ b/src/app/visningskomponenter/ytelser/vedtaksliste.tsx
@@ -1,4 +1,3 @@
-import Normaltekst from "nav-frontend-typografi/lib/normaltekst";
 import * as React from 'react';
 import {YtelseDataType} from "../../datatyper/ytelse";
 import EMDASH from "../../utils/emdash.js";
@@ -7,6 +6,7 @@ import {isNullOrUndefined} from "../../utils/util";
 import {formaterDato} from "../felles-komponenter/dato";
 import Informasjonsbolk from "../felles-komponenter/informasjonsbolk";
 import InformasjonsbolkEnkel from "../felles-komponenter/informasjonsbolk-enkel";
+import NormalTekstWrapper from "../felles-komponenter/normaltekstwrapper";
 import {StringOrNothing} from "../felles-typer";
 
 function Vedtaksliste(props: Pick<YtelseDataType, 'vedtaksliste'>) {
@@ -27,8 +27,8 @@ function Vedtaksliste(props: Pick<YtelseDataType, 'vedtaksliste'>) {
             <InformasjonsbolkEnkel header="Vedtakstatus" value={visEmdashHvisNull(vedtak.status)} />
             <InformasjonsbolkEnkel header="Aktivitetsfase" value={visEmdashHvisNull(vedtak.aktivitetsfase)} />
             <Informasjonsbolk header="Vedtaksperiode" {...props}>
-                { vedtak.fradato && <Normaltekst> Fra: {formaterDato(vedtak.fradato)} </Normaltekst> }
-                { vedtak.tildato && <Normaltekst> Til: {formaterDato(vedtak.tildato)} </Normaltekst> }
+                <NormalTekstWrapper label="Fra: " value={formaterDato(vedtak.fradato)} />
+                <NormalTekstWrapper label="Til: " value={formaterDato(vedtak.tildato)} />
             </Informasjonsbolk>
         </Grid>
     ));

--- a/src/app/visningskomponenter/ytelser/vedtaksliste.tsx
+++ b/src/app/visningskomponenter/ytelser/vedtaksliste.tsx
@@ -27,8 +27,8 @@ function Vedtaksliste(props: Pick<YtelseDataType, 'vedtaksliste'>) {
             <InformasjonsbolkEnkel header="Vedtakstatus" value={visEmdashHvisNull(vedtak.status)} />
             <InformasjonsbolkEnkel header="Aktivitetsfase" value={visEmdashHvisNull(vedtak.aktivitetsfase)} />
             <Informasjonsbolk header="Vedtaksperiode" {...props}>
-                <Normaltekst>{vedtak.fradato && `Fra: ${formaterDato(vedtak.fradato)}`}</Normaltekst>
-                <Normaltekst>{vedtak.tildato && `Til: ${formaterDato(vedtak.tildato)}`}</Normaltekst>
+                { vedtak.fradato && <Normaltekst> Fra: {formaterDato(vedtak.fradato)} </Normaltekst> }
+                { vedtak.tildato && <Normaltekst> Til: {formaterDato(vedtak.tildato)} </Normaltekst> }
             </Informasjonsbolk>
         </Grid>
     ));

--- a/src/mock/personalia.ts
+++ b/src/mock/personalia.ts
@@ -83,7 +83,15 @@ const Personalia = {
     },
     "midlertidigAdresseNorge": null,
     "midlertidigAdresseUtland": null,
-    "postAdresse": "PB 134, 1621 GRESSVIK",
+    "postAdresse": {
+        "ustrukturertAdresse": {
+            "adresselinje1": "DOIDGE",
+            "adresselinje2": null,
+            "adresselinje3": null,
+            "adresselinje4": "4001 STAVANGER",
+            "landkode": "NORGE"
+        }
+    },
     "egenAnsatt": true,
     "kjonn": "K"
 };


### PR DESCRIPTION
Hvis "Normaltekst" blir brukt med nullverdi så får vi varsel(feilmelding) i konsollen. Da har jeg lagt nullsjekk før hver Normaltekst element i koden. Men hvis vi bruker "span" isteden for "Normaltekst" så trenger vi ikke legge nullsjekk. Kan vi bruke "span" i stedet "Normaltekst" eller hva er fordeler med å bruke "Normaltekst" enn "span"?