### PR TITLE
TC-30 fjern fraDato og refaktorer safeSort

### DIFF
--- a/src/components/paneler/innhold/cv/kurs.tsx
+++ b/src/components/paneler/innhold/cv/kurs.tsx
@@ -6,12 +6,11 @@ import { formaterDato, formaterVarighet, safeSort, safeMap } from '../../../../u
 
 function Kurs(props: Pick<ArenaPerson, 'kurs'>) {
 	const { kurs: arenaKurs, ...rest } = props;
-	const sortedKurs = arenaKurs.sort((a, b) => safeSort(b.fraDato, a.fraDato));
+	const sortedKurs = arenaKurs.sort((a, b) => safeSort(b.tidspunkt, a.tidspunkt));
 	const kurs = safeMap(sortedKurs, (enkeltKurs, index) => (
 		<div key={`kurs-${index}`} className="underinformasjon">
 			<Element>{enkeltKurs.tittel}</Element>
 			<Normaltekst>{enkeltKurs.arrangor}</Normaltekst>
-			{enkeltKurs.fraDato && <Normaltekst>Fra: {formaterDato(enkeltKurs.fraDato)}</Normaltekst>}
 			{enkeltKurs.tidspunkt && <Normaltekst>Fullført: {formaterDato(enkeltKurs.tidspunkt)}</Normaltekst>}
 			{enkeltKurs.varighet && <Normaltekst>Varighet: {formaterVarighet(enkeltKurs.varighet)}</Normaltekst>}
 		</div>

--- a/src/mock/api/veilarbperson.ts
+++ b/src/mock/api/veilarbperson.ts
@@ -1,11 +1,11 @@
-import {rest} from 'msw';
-import {RequestHandlersList} from 'msw/lib/types/setupWorker/glossary';
-import {ArenaPerson, FagdokumentType, KursVarighetEnhet} from '../../rest/datatyper/arenaperson';
-import {PersonaliaInfo} from '../../rest/datatyper/personalia';
-import {AktorId} from '../../rest/datatyper/aktor-id';
-import {Gradering, PersonaliaV2Info} from "../../rest/datatyper/personaliav2";
-import {VergemaalEllerFullmaktOmfangType, VergeOgFullmaktData, Vergetype} from "../../rest/datatyper/vergeOgFullmakt";
-import {TilrettelagtKommunikasjonData} from "../../rest/datatyper/tilrettelagtKommunikasjon";
+import { rest } from 'msw';
+import { RequestHandlersList } from 'msw/lib/types/setupWorker/glossary';
+import { ArenaPerson, FagdokumentType, KursVarighetEnhet } from '../../rest/datatyper/arenaperson';
+import { PersonaliaInfo } from '../../rest/datatyper/personalia';
+import { AktorId } from '../../rest/datatyper/aktor-id';
+import { Gradering, PersonaliaV2Info } from '../../rest/datatyper/personaliav2';
+import { VergemaalEllerFullmaktOmfangType, VergeOgFullmaktData, Vergetype } from '../../rest/datatyper/vergeOgFullmakt';
+import { TilrettelagtKommunikasjonData } from '../../rest/datatyper/tilrettelagtKommunikasjon';
 
 const aktorId: AktorId = {
 	aktorId: '1234567'
@@ -101,7 +101,7 @@ const cvOgJobbprofil: ArenaPerson = {
 		{
 			tittel: 'huet',
 			arrangor: 'falk',
-			fraDato: '2016-10',
+			tidspunkt: '2016-10',
 			varighet: {
 				varighet: 1,
 				tidsenhet: KursVarighetEnhet.UKE
@@ -110,18 +110,18 @@ const cvOgJobbprofil: ArenaPerson = {
 		{
 			tittel: 'grønn',
 			arrangor: 'falk',
-			tidspunkt: '2017-10',
+			tidspunkt: '2017-10'
 		},
 		{
 			tittel: 'blå',
 			arrangor: 'falk',
 			fraDato: '2018-10',
-			tidspunkt: '2018-10',
+			tidspunkt: '2018-10'
 		},
 		{
 			tittel: 'dynamik posisjonering',
 			arrangor: 'kongsberg',
-			fraDato: '2010-08'
+			tidspunkt: '2010-08'
 		}
 	],
 	godkjenninger: [
@@ -444,7 +444,8 @@ const personaliav2: PersonaliaV2Info = {
 			prioritet: '2',
 			telefonNr: '+4822222222',
 			master: 'KRR'
-		}],
+		}
+	],
 	epost: 'tester.scrambling-script@fellesregistre.no',
 	statsborgerskap: 'Norge',
 	sivilstand: {
@@ -583,46 +584,46 @@ const mockVergeOgFullmakt: VergeOgFullmaktData = {
 		{
 			motpartsPersonident: '1234567890',
 			motpartsPersonNavn: {
-				fornavn:'Ola',
-				mellomnavn:null,
-				etternavn:'Nordmann',
-				forkortetNavn:'Nordmann Ola'
+				fornavn: 'Ola',
+				mellomnavn: null,
+				etternavn: 'Nordmann',
+				forkortetNavn: 'Nordmann Ola'
 			},
 			motpartsRolle: 'FULLMEKTIG',
 			omraader: [
 				{
-					kode:'AAP',
-					beskrivelse:'Arbeidsavklaringspenger'
+					kode: 'AAP',
+					beskrivelse: 'Arbeidsavklaringspenger'
 				},
 				{
-					kode:'DAG',
-					beskrivelse:'Dagpenger'
+					kode: 'DAG',
+					beskrivelse: 'Dagpenger'
 				}
 			],
 			gyldigFraOgMed: '2021-03-02T13:00:42',
-			gyldigTilOgMed:	'2021-03-03T13:00:42'
+			gyldigTilOgMed: '2021-03-03T13:00:42'
 		},
 		{
 			motpartsPersonident: '1234567891',
 			motpartsPersonNavn: {
-				fornavn:'fornavn',
-				mellomnavn:'mellomnavn',
-				etternavn:'etternavn',
-				forkortetNavn:'forkortetNavn'
+				fornavn: 'fornavn',
+				mellomnavn: 'mellomnavn',
+				etternavn: 'etternavn',
+				forkortetNavn: 'forkortetNavn'
 			},
 			motpartsRolle: 'FULLMAKTSGIVER',
-			omraader:[
+			omraader: [
 				{
-					kode:'BAR',
-					beskrivelse:'Barnetrygd'
+					kode: 'BAR',
+					beskrivelse: 'Barnetrygd'
 				},
 				{
-					kode:'HJE',
-					beskrivelse:'Hjelpemidler'
+					kode: 'HJE',
+					beskrivelse: 'Hjelpemidler'
 				}
 			],
 			gyldigFraOgMed: '2021-03-04T13:00:42',
-			gyldigTilOgMed:	'2021-03-05T13:00:42'
+			gyldigTilOgMed: '2021-03-05T13:00:42'
 		}
 	]
 };

--- a/src/rest/datatyper/arenaperson.ts
+++ b/src/rest/datatyper/arenaperson.ts
@@ -59,7 +59,6 @@ interface Sprak {
 interface Kurs {
 	tittel: StringOrNothing;
 	arrangor: StringOrNothing;
-	fraDato?: YearMonth;
 	tidspunkt?: YearMonth;
 	varighet?: Kursvarighet;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -91,10 +91,12 @@ export function formaterDato(datoObjekt: DatoType | string | undefined | null, o
 }
 
 export function safeSort(a: StringOrNothing, b: StringOrNothing) {
-	if (a) {
-		return b ? a.localeCompare(b) : -1;
+	if (a && b) {
+		return a.localeCompare(b);
+	} else if (a) {
+		return -1;
 	} else if (b) {
-		return a ? b.localeCompare(a) : 1;
+		return 1;
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
Fjerner `fraDato` fra kurs i CV (erstattet med `tidspunkt`) og gjør `safeSort`-funksjonen litt mer forståelig