### PR TITLE
Viser enten servicegruppe eller innsatsgruppe+hovedmål

### DIFF
--- a/src/components/paneler/innhold/oppfolging/oppfolging-panel-innhold.tsx
+++ b/src/components/paneler/innhold/oppfolging/oppfolging-panel-innhold.tsx
@@ -20,6 +20,7 @@ import {
 	mapInnsatsgruppeTilTekst,
 	mapServicegruppeTilTekst
 } from '../../../../utils/text-mapper';
+import { erInnsatsgruppe } from '../../../../utils/arena-status-utils';
 
 const OppfolgingPanelInnhold = () => {
 	const { fnr } = useAppStore();
@@ -46,16 +47,31 @@ const OppfolgingPanelInnhold = () => {
 	const innsatsbehovData = hasData(innsatsbehov) ? innsatsbehov.data : null;
 	const oppfolgingsstatusData = hasData(oppfolgingsstatus) ? oppfolgingsstatus.data : null;
 
+
+	let servicegruppe = oppfolgingsstatusData?.servicegruppe;
+	let innsatsgruppe = innsatsbehovData?.innsatsgruppe;
+	let hovedmal = innsatsbehovData?.hovedmal;
+	// Vi bruker servicegruppe fra Arena som master for om vi skal vise servicegruppe eller innsatsgruppe + hovedmål:
+	// Hvis servicegruppe fra Arena er en innsatsgruppe, så viser vi innsatsgruppe + hovedmål fra vedtaksstøtte.
+	// Ellers viser vi bare servicegruppe fra Arena, siden det da har blitt satt en servicegruppe i Arena som er
+	// nyere enn innsagsgruppe + hovedmål fra vedtaksstøtte.
+	if (erInnsatsgruppe(oppfolgingsstatusData?.servicegruppe)) {
+		servicegruppe = undefined;
+	} else {
+		innsatsgruppe = undefined;
+		hovedmal = undefined;
+	}
+
 	return (
 		<Grid columns={4} gap="0.5rem">
 			<InformasjonsbolkEnkel
 				header="Servicegruppe"
-				value={mapServicegruppeTilTekst(oppfolgingsstatusData?.servicegruppe)}
+				value={mapServicegruppeTilTekst(servicegruppe)}
 				defaultValue={EMDASH}
 			/>
 			<InformasjonsbolkEnkel
 				header="Innsatsgruppe"
-				value={mapInnsatsgruppeTilTekst(innsatsbehovData?.innsatsgruppe)}
+				value={mapInnsatsgruppeTilTekst(innsatsgruppe)}
 				defaultValue={EMDASH}
 			/>
 			<InformasjonsbolkEnkel header="Veileder" value={hentVeilederTekst(veilederData)} defaultValue={EMDASH} />
@@ -71,7 +87,7 @@ const OppfolgingPanelInnhold = () => {
 			/>
 			<InformasjonsbolkEnkel
 				header="Hovedmål"
-				value={mapHovedmalTilTekst(innsatsbehovData?.hovedmal)}
+				value={mapHovedmalTilTekst(hovedmal)}
 				defaultValue={EMDASH}
 			/>
 		</Grid>

--- a/src/components/paneler/innhold/ytelser/ytelser-panel-innhold.tsx
+++ b/src/components/paneler/innhold/ytelser/ytelser-panel-innhold.tsx
@@ -4,13 +4,14 @@ import Grid from '../../../felles/grid';
 import Vedtaksliste from './vedtaksliste';
 import { VedtakType } from '../../../../rest/datatyper/ytelse';
 import { VEDTAKSSTATUSER } from '../../../../utils/konstanter';
-import { useFetchInnsatsbehov, useFetchYtelser } from '../../../../rest/api';
+import { useFetchInnsatsbehov, useFetchOppfolgingsstatus, useFetchYtelser } from '../../../../rest/api';
 import { Feilmelding, Laster, NoData } from '../../../felles/fetch';
 import { isPending, hasError } from '@nutgaard/use-fetch';
 import { hasData } from '../../../../rest/utils';
 import { mapInnsatsgruppeTilTekst } from '../../../../utils/text-mapper';
 import EMDASH from '../../../../utils/emdash';
 import InformasjonsbolkEnkel from '../../../felles/informasjonsbolk-enkel';
+import { erInnsatsgruppe } from '../../../../utils/arena-status-utils';
 
 const getVedtakForVisning = (vedtaksliste: VedtakType[]) => {
 	return vedtaksliste.filter(vedtak => vedtak.status === VEDTAKSSTATUSER.iverksatt);
@@ -19,9 +20,10 @@ const getVedtakForVisning = (vedtaksliste: VedtakType[]) => {
 const YtelserPanelInnhold = () => {
 	const { fnr } = useAppStore();
 	const ytelser = useFetchYtelser(fnr);
+	const oppfolgingsstatus = useFetchOppfolgingsstatus(fnr);
 	const innsatsbehov = useFetchInnsatsbehov(fnr);
 
-	if (isPending(ytelser) || isPending(innsatsbehov)) {
+	if (isPending(ytelser) || isPending(innsatsbehov) || isPending(oppfolgingsstatus)) {
 		return <Laster midtstilt={true} />;
 	} else if (hasError(ytelser)) {
 		return <Feilmelding />;
@@ -32,12 +34,18 @@ const YtelserPanelInnhold = () => {
 	const { vedtaksliste } = ytelser.data;
 	const aktivVedtak = getVedtakForVisning(vedtaksliste);
 	const innsatsbehovData = hasData(innsatsbehov) ? innsatsbehov.data : null;
+	const oppfolgingsstatusData = hasData(oppfolgingsstatus) ? oppfolgingsstatus.data : null;
+
+	let innsatsgruppe = innsatsbehovData?.innsatsgruppe
+	if (!erInnsatsgruppe(oppfolgingsstatusData?.servicegruppe)) {
+		innsatsgruppe = undefined;
+	}
 
 	return (
 		<Grid columns={1} gap="0.5rem">
 			<InformasjonsbolkEnkel
 				header="Innsatsgruppe"
-				value={mapInnsatsgruppeTilTekst(innsatsbehovData?.innsatsgruppe)}
+				value={mapInnsatsgruppeTilTekst(innsatsgruppe)}
 				defaultValue={EMDASH}
 			/>
 			<Vedtaksliste vedtaksliste={aktivVedtak}/>

--- a/src/utils/arena-status-utils.ts
+++ b/src/utils/arena-status-utils.ts
@@ -1,5 +1,18 @@
-import { OppfolgingsstatusData } from '../rest/datatyper/oppfolgingsstatus';
+import { OppfolgingsstatusData, Servicegruppe } from '../rest/datatyper/oppfolgingsstatus';
+import { OrNothing } from './felles-typer';
 
 export function erBrukerSykmeldt(oppfolging: OppfolgingsstatusData): boolean {
 	return oppfolging.formidlingsgruppe === 'IARBS' && oppfolging.servicegruppe === 'VURDI';
+}
+
+export function erInnsatsgruppe(kvalifiseringsgruppe: OrNothing<Servicegruppe>) {
+	switch (kvalifiseringsgruppe) {
+		case 'IKVAL':
+		case 'BATT':
+		case 'BFORM':
+		case 'VARIG':
+			return true;
+		default:
+			return false;
+	}
 }


### PR DESCRIPTION
Dersom servicegruppe fra Arena er en innsatsgruppe, så vises innsatsgruppe+hovedmål fra vedtaksstøtte. Hvis ikke, vises bare servicegruppe fra Arena.

Co-authored-by: emildohlenhansen <emil.dolen.hansen@nav.no>