### PR TITLE
Hent innsatsgruppe og hovedmål fra Arena som default

### DIFF
--- a/src/components/paneler/innhold/oppfolging/oppfolging-panel-innhold.less
+++ b/src/components/paneler/innhold/oppfolging/oppfolging-panel-innhold.less
@@ -1,0 +1,6 @@
+.veilarbmaofs {
+  .alert-hovedmal-vedtaksstotte .alertstripe__tekst {
+    max-width: 100%;
+  }
+
+}

--- a/src/components/paneler/innhold/ytelser/ytelser-panel-innhold.tsx
+++ b/src/components/paneler/innhold/ytelser/ytelser-panel-innhold.tsx
@@ -6,12 +6,11 @@ import { VedtakType } from '../../../../rest/datatyper/ytelse';
 import { VEDTAKSSTATUSER } from '../../../../utils/konstanter';
 import { useFetchInnsatsbehov, useFetchOppfolgingsstatus, useFetchYtelser } from '../../../../rest/api';
 import { Feilmelding, Laster, NoData } from '../../../felles/fetch';
-import { isPending, hasError } from '@nutgaard/use-fetch';
+import { hasError, isPending } from '@nutgaard/use-fetch';
 import { hasData } from '../../../../rest/utils';
 import { mapInnsatsgruppeTilTekst } from '../../../../utils/text-mapper';
 import EMDASH from '../../../../utils/emdash';
 import InformasjonsbolkEnkel from '../../../felles/informasjonsbolk-enkel';
-import { erInnsatsgruppe } from '../../../../utils/arena-status-utils';
 
 const getVedtakForVisning = (vedtaksliste: VedtakType[]) => {
 	return vedtaksliste.filter(vedtak => vedtak.status === VEDTAKSSTATUSER.iverksatt);
@@ -33,19 +32,13 @@ const YtelserPanelInnhold = () => {
 
 	const { vedtaksliste } = ytelser.data;
 	const aktivVedtak = getVedtakForVisning(vedtaksliste);
-	const innsatsbehovData = hasData(innsatsbehov) ? innsatsbehov.data : null;
 	const oppfolgingsstatusData = hasData(oppfolgingsstatus) ? oppfolgingsstatus.data : null;
-
-	let innsatsgruppe = innsatsbehovData?.innsatsgruppe
-	if (!erInnsatsgruppe(oppfolgingsstatusData?.servicegruppe)) {
-		innsatsgruppe = undefined;
-	}
 
 	return (
 		<Grid columns={1} gap="0.5rem">
 			<InformasjonsbolkEnkel
 				header="Innsatsgruppe"
-				value={mapInnsatsgruppeTilTekst(innsatsgruppe)}
+				value={mapInnsatsgruppeTilTekst(oppfolgingsstatusData?.servicegruppe)}
 				defaultValue={EMDASH}
 			/>
 			<Vedtaksliste vedtaksliste={aktivVedtak}/>

--- a/src/mock/api/veilarbpersonflatefs.ts
+++ b/src/mock/api/veilarbpersonflatefs.ts
@@ -1,11 +1,18 @@
 import { rest } from 'msw';
 import { RequestHandlersList } from 'msw/lib/types/setupWorker/glossary';
-import {Features, PERSONALIA_DATA_FRA_PDL, PERSONALIA_DATA_FRA_TPS, SPOR_OM_TILBAKEMELDING} from "../../rest/datatyper/feature";
+import {
+	Features,
+	PERSONALIA_DATA_FRA_PDL,
+	PERSONALIA_DATA_FRA_TPS,
+	SPOR_OM_TILBAKEMELDING,
+	INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE,
+} from '../../rest/datatyper/feature';
 
 const features: Features = {
 	[PERSONALIA_DATA_FRA_PDL]: true,
 	[PERSONALIA_DATA_FRA_TPS]: false,
-	[SPOR_OM_TILBAKEMELDING]: true
+	[SPOR_OM_TILBAKEMELDING]: true,
+	[INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE]: false
 };
 
 export const veilarbpersonflatefsHandlers: RequestHandlersList = [

--- a/src/mock/api/veilarbvedtaksstotte.ts
+++ b/src/mock/api/veilarbvedtaksstotte.ts
@@ -7,9 +7,15 @@ const innsatsbehov: Innsatsbehov = {
 	hovedmal: Hovedmal.BEHOLDE_ARBEID
 };
 
+const tilhorerBrukerUtrulletKontor = false;
+
 export const veilarbvedtaksstotteHandlers: RequestHandlersList = [
 	rest.get('/veilarbvedtaksstotte/api/innsatsbehov', (req, res, ctx) => {
 		return res(ctx.delay(500), ctx.json(innsatsbehov));
+	}),
+
+	rest.get('/veilarbvedtaksstotte/api/utrulling/tilhorerBrukerUtrulletKontor', (req, res, ctx) => {
+		return res(ctx.delay(500), ctx.json(tilhorerBrukerUtrulletKontor));
 	}),
 ];
 

--- a/src/rest/api.ts
+++ b/src/rest/api.ts
@@ -4,7 +4,7 @@ import { RegistreringsData } from './datatyper/registreringsData';
 import { ArenaPerson } from './datatyper/arenaperson';
 import { VeilederData } from './datatyper/veileder';
 import { AktorId } from './datatyper/aktor-id';
-import { OppfolgingsstatusData } from './datatyper/oppfolgingsstatus';
+import { OppfolgingEnhet, OppfolgingsstatusData } from './datatyper/oppfolgingsstatus';
 import { KartleggingData } from './datatyper/kartlegging';
 import { YtelseData } from './datatyper/ytelse';
 import { UnderOppfolgingData } from './datatyper/underOppfolgingData';
@@ -55,3 +55,7 @@ export const useFetchInnsatsbehov = (fnr: string) =>
 const toggles = TOGGLES.map(element => 'feature=' + element).join('&');
 
 export const useFetchFeatureToggle = () => useFetch<Features>(`/veilarbpersonflatefs/api/feature?${toggles}`, headers);
+
+export function useFetchTilgorerBrukerUtrulletKontorForVedtaksstotte(fnr: string) {
+	return useFetch<boolean>(`/veilarbvedtaksstotte/api/utrulling/tilhorerBrukerUtrulletKontor?fnr=${fnr}`, headers);
+}

--- a/src/rest/datatyper/feature.ts
+++ b/src/rest/datatyper/feature.ts
@@ -1,15 +1,18 @@
 export const PERSONALIA_DATA_FRA_PDL = 'veilarbmaofs.personalia.pdl.persondata';
 export const PERSONALIA_DATA_FRA_TPS = 'veilarbmaofs.personalia.tps.persondata';
 export const SPOR_OM_TILBAKEMELDING = 'veilarbmaofs.spor.om.tilbakemelding';
+export const INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE = 'veilarbmaofs.hent_innsatsgruppe_og_hovedmal_fra_vedtaksstotte';
 
 export const TOGGLES = [
 	PERSONALIA_DATA_FRA_PDL,
 	PERSONALIA_DATA_FRA_TPS,
-	SPOR_OM_TILBAKEMELDING
+	SPOR_OM_TILBAKEMELDING,
+	INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE
 ];
 
 export interface Features {
 	[PERSONALIA_DATA_FRA_PDL]: boolean;
 	[PERSONALIA_DATA_FRA_TPS]: boolean;
 	[SPOR_OM_TILBAKEMELDING]: boolean;
+	[INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE]: boolean;
 }

--- a/src/rest/datatyper/oppfolgingsstatus.ts
+++ b/src/rest/datatyper/oppfolgingsstatus.ts
@@ -4,14 +4,14 @@ export interface OppfolgingEnhet {
 	navn: StringOrNothing;
 	enhetId: StringOrNothing;
 }
-export type Formidlingsgruppe = 'ARBS' | 'IARBS' | 'ISERV' | 'PARBS' | 'RARBS';
-export type Servicegruppe = 'BATT' | 'BFORM' | 'BKART' | 'IKVAL' | 'IVURD' | 'KAP11' | 'OPPFI' | 'VARIG' | 'VURDI' | 'VURDU';
-export type Hovedmaalgruppe = 'OKEDELT' | 'SKAFFEA ' | 'BEHOLDEA';
+export type ArenaFormidlingsgruppeKode = 'ARBS' | 'IARBS' | 'ISERV' | 'PARBS' | 'RARBS';
+export type ArenaServicegruppeKode = 'BATT' | 'BFORM' | 'BKART' | 'IKVAL' | 'IVURD' | 'KAP11' | 'OPPFI' | 'VARIG' | 'VURDI' | 'VURDU';
+export type ArenaHovedmalKode = 'OKEDELT' | 'SKAFFEA' | 'BEHOLDEA';
 
 export interface OppfolgingsstatusData {
 	oppfolgingsenhet: OppfolgingEnhet;
 	veilederId: StringOrNothing;
-	formidlingsgruppe: OrNothing<Formidlingsgruppe>;
-	servicegruppe: OrNothing<Servicegruppe>;
-	hovedmaalkode: OrNothing<Hovedmaalgruppe>;
+	formidlingsgruppe: OrNothing<ArenaFormidlingsgruppeKode>;
+	servicegruppe: OrNothing<ArenaServicegruppeKode>;
+	hovedmaalkode: OrNothing<ArenaHovedmalKode>;
 }

--- a/src/utils/arena-status-utils.ts
+++ b/src/utils/arena-status-utils.ts
@@ -1,11 +1,11 @@
-import { OppfolgingsstatusData, Servicegruppe } from '../rest/datatyper/oppfolgingsstatus';
+import { OppfolgingsstatusData, ArenaServicegruppeKode } from '../rest/datatyper/oppfolgingsstatus';
 import { OrNothing } from './felles-typer';
 
 export function erBrukerSykmeldt(oppfolging: OppfolgingsstatusData): boolean {
 	return oppfolging.formidlingsgruppe === 'IARBS' && oppfolging.servicegruppe === 'VURDI';
 }
 
-export function erInnsatsgruppe(kvalifiseringsgruppe: OrNothing<Servicegruppe>) {
+export function erInnsatsgruppe(kvalifiseringsgruppe: OrNothing<ArenaServicegruppeKode>) {
 	switch (kvalifiseringsgruppe) {
 		case 'IKVAL':
 		case 'BATT':

--- a/src/utils/text-mapper.ts
+++ b/src/utils/text-mapper.ts
@@ -1,11 +1,11 @@
 import { Hovedmal, Innsatsgruppe } from '../rest/datatyper/innsatsbehov';
 import EMDASH from './emdash';
-import { OppfolgingsstatusData, Servicegruppe } from '../rest/datatyper/oppfolgingsstatus';
+import { ArenaHovedmalKode, OppfolgingsstatusData, ArenaServicegruppeKode } from '../rest/datatyper/oppfolgingsstatus';
 import { OrNothing, StringOrNothing } from './felles-typer';
 import { PersonaliaInfo } from '../rest/datatyper/personalia';
 import { VeilederData } from '../rest/datatyper/veileder';
 
-export function mapServicegruppeTilTekst(servicegruppe: OrNothing<Servicegruppe>): string {
+export function mapServicegruppeTilTekst(servicegruppe: OrNothing<ArenaServicegruppeKode>): string {
 	switch (servicegruppe) {
 		case 'IVURD':
 			return 'Ikke vurdert';
@@ -24,30 +24,37 @@ export function mapServicegruppeTilTekst(servicegruppe: OrNothing<Servicegruppe>
 	}
 }
 
-export function mapHovedmalTilTekst(hovedmal: OrNothing<Hovedmal>): string {
+export function mapHovedmalTilTekst(hovedmal: OrNothing<Hovedmal | ArenaHovedmalKode>): string {
 	switch (hovedmal) {
 		case Hovedmal.BEHOLDE_ARBEID:
+		case 'BEHOLDEA':
 			return 'Beholde arbeid';
 		case Hovedmal.OKE_DELTAKELSE:
+		case 'OKEDELT':
 			return 'Øke deltakelse eller mål om arbeid';
 		case Hovedmal.SKAFFE_ARBEID:
+		case 'SKAFFEA':
 			return 'Skaffe arbeid';
 		default:
 			return EMDASH;
 	}
 }
 
-export function mapInnsatsgruppeTilTekst(innsatsgruppe: OrNothing<Innsatsgruppe>): string {
+export function mapInnsatsgruppeTilTekst(innsatsgruppe: OrNothing<Innsatsgruppe | ArenaServicegruppeKode>): string {
 	switch (innsatsgruppe) {
 		case Innsatsgruppe.STANDARD_INNSATS:
+		case 'IKVAL':
 			return 'Standardinnsats';
 		case Innsatsgruppe.SITUASJONSBESTEMT_INNSATS:
+		case 'BFORM':
 			return 'Situasjonsbestemt innsats';
 		case Innsatsgruppe.SPESIELT_TILPASSET_INNSATS:
+		case 'BATT':
 			return 'Spesielt tilpasset innsats';
 		case Innsatsgruppe.GRADERT_VARIG_TILPASSET_INNSATS:
 			return 'Gradert varig tilpasset innsats';
 		case Innsatsgruppe.VARIG_TILPASSET_INNSATS:
+		case 'VARIG':
 			return 'Varig tilpasset innsats';
 		default:
 			return EMDASH;


### PR DESCRIPTION
Lagt henting fra vedtaksstøtte bak feature toggle. Foreløpig ikke feature toggle for innsatsgruppe i ytelser-panel, bør kanskje heller vurdere å ta bort innsatsgruppe fra dette panelet.