### PR TITLE
Fjern jobbsokerkompetanse-kallet

### DIFF
--- a/src/components/paneler/innhold/jobbsokerkompetanse/jobbsokerkompetanse-panel-innhold.tsx
+++ b/src/components/paneler/innhold/jobbsokerkompetanse/jobbsokerkompetanse-panel-innhold.tsx
@@ -1,52 +1,7 @@
-import React from 'react';
-import { useAppStore } from '../../../../stores/app-store';
-import SistEndret from '../../../felles/sist-endret';
-import Grid from '../../../felles/grid';
-import InformasjonsbolkPunktliste from '../../../felles/informasjonsbolk-punktliste';
-import Informasjonsbolk from '../../../felles/informasjonsbolk';
-import { safeMap } from '../../../../utils';
-import { RaadVisning } from './raad-visning';
-import { useFetchJobbsokerkompetanse } from '../../../../rest/api';
-import { Feilmelding, Laster, NoData } from '../../../felles/fetch';
-import { isPending, hasError } from '@nutgaard/use-fetch';
-import { hasData } from '../../../../rest/utils';
+import { NoData } from '../../../felles/fetch';
 
 const JobbsokerkompetansePanelInnhold = () => {
-	const { fnr } = useAppStore();
-	const jobbsokerkompetanse = useFetchJobbsokerkompetanse(fnr);
-
-	if (isPending(jobbsokerkompetanse)) {
-		return <Laster midtstilt={true} />;
-	} else if (hasError(jobbsokerkompetanse)) {
-		return <Feilmelding />;
-	} else if (!hasData(jobbsokerkompetanse)) {
-		return <NoData />;
-	}
-
-	const { besvarelseDato, kulepunkter, raad } = jobbsokerkompetanse.data;
-	const kulepunktListe = kulepunkter.map(punkt => punkt.kulepunkt);
-
-	const raadliste = safeMap(raad, (rad, index) => (
-		<li key={index}>
-			<RaadVisning raad={rad} />
-		</li>
-	));
-
-	return (
-		<>
-			<SistEndret sistEndret={besvarelseDato} onlyYearAndMonth={false} />
-			<Grid columns={1} gap="0rem">
-				<InformasjonsbolkPunktliste
-					header="Dette gjør du bra"
-					list={kulepunktListe}
-					className="jobbsokerkompetanse__punktliste"
-				/>
-				<Informasjonsbolk header="Dette kan du gjøre bedre" className="jobbsokerkompetanse__raadliste">
-					<ul>{raadliste}</ul>
-				</Informasjonsbolk>
-			</Grid>
-		</>
-	);
+	return <NoData />;
 };
 
 export default JobbsokerkompetansePanelInnhold;

--- a/src/rest/api.ts
+++ b/src/rest/api.ts
@@ -5,14 +5,13 @@ import { ArenaPerson } from './datatyper/arenaperson';
 import { VeilederData } from './datatyper/veileder';
 import { AktorId } from './datatyper/aktor-id';
 import { OppfolgingsstatusData } from './datatyper/oppfolgingsstatus';
-import { KartleggingData } from './datatyper/kartlegging';
 import { YtelseData } from './datatyper/ytelse';
 import { UnderOppfolgingData } from './datatyper/underOppfolgingData';
 import { OrNothing } from '../utils/felles-typer';
 import { PersonaliaV2Info } from './datatyper/personaliav2';
 import { TOGGLES, Features } from './datatyper/feature';
-import { VergeOgFullmaktData} from "./datatyper/vergeOgFullmakt";
-import { TilrettelagtKommunikasjonData} from "./datatyper/tilrettelagtKommunikasjon";
+import { VergeOgFullmaktData } from './datatyper/vergeOgFullmakt';
+import { TilrettelagtKommunikasjonData } from './datatyper/tilrettelagtKommunikasjon';
 import { Innsatsbehov } from './datatyper/innsatsbehov';
 import { APP_NAME } from '../utils/konstanter';
 
@@ -23,31 +22,35 @@ const headers = {
 export const useFetchRegistrering = (fnr: string) =>
 	useFetch<RegistreringsData>(`/veilarbregistrering/api/registrering?fnr=${fnr}`, headers);
 
-export const useFetchCvOgJobbprofil = (fnr: string) => useFetch<ArenaPerson>(`/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`);
+export const useFetchCvOgJobbprofil = (fnr: string) =>
+	useFetch<ArenaPerson>(`/veilarbperson/api/person/cv_jobbprofil?fnr=${fnr}`);
 
 export const useFetchVeileder = (veilederId: OrNothing<string>, config?: Config) =>
 	useFetch<VeilederData>(`/veilarbveileder/api/veileder/${veilederId}`, headers, config);
 
-export const useFetchAktorId = (fnr: string) => useFetch<AktorId>(`/veilarbperson/api/person/aktorid?fnr=${fnr}`, headers);
+export const useFetchAktorId = (fnr: string) =>
+	useFetch<AktorId>(`/veilarbperson/api/person/aktorid?fnr=${fnr}`, headers);
 
 export const useFetchOppfolgingsstatus = (fnr: string) =>
 	useFetch<OppfolgingsstatusData>(`/veilarboppfolging/api/person/${fnr}/oppfolgingsstatus`, headers);
 
-export const useFetchJobbsokerkompetanse = (fnr: string) =>
-	useFetch<KartleggingData>(`/veilarbjobbsokerkompetanse/api/hent?fnr=${fnr}`, headers);
-
-export const useFetchYtelser = (fnr: string) => useFetch<YtelseData>(`/veilarboppfolging/api/person/${fnr}/ytelser`, headers);
+export const useFetchYtelser = (fnr: string) =>
+	useFetch<YtelseData>(`/veilarboppfolging/api/person/${fnr}/ytelser`, headers);
 
 export const useFetchUnderOppfolging = (fnr: string) =>
 	useFetch<UnderOppfolgingData>(`/veilarboppfolging/api/underoppfolging?fnr=${fnr}`, headers);
 
-export const useFetchPersonalia = (fnr: string) => useFetch<PersonaliaInfo>(`/veilarbperson/api/person/${fnr}`, headers);
+export const useFetchPersonalia = (fnr: string) =>
+	useFetch<PersonaliaInfo>(`/veilarbperson/api/person/${fnr}`, headers);
 
-export const useFetchPersonaliaV2 = (fnr: string) => useFetch<PersonaliaV2Info>(`/veilarbperson/api/v2/person?fnr=${fnr}`, headers);
+export const useFetchPersonaliaV2 = (fnr: string) =>
+	useFetch<PersonaliaV2Info>(`/veilarbperson/api/v2/person?fnr=${fnr}`, headers);
 
-export const useFetchVergOgFullmakt = (fnr: string) => useFetch<VergeOgFullmaktData>(`/veilarbperson/api/v2/person/vergeOgFullmakt?fnr=${fnr}`, headers);
+export const useFetchVergOgFullmakt = (fnr: string) =>
+	useFetch<VergeOgFullmaktData>(`/veilarbperson/api/v2/person/vergeOgFullmakt?fnr=${fnr}`, headers);
 
-export const useFetchSpraakTolk = (fnr: string) => useFetch<TilrettelagtKommunikasjonData>(`/veilarbperson/api/v2/person/tolk?fnr=${fnr}`, headers);
+export const useFetchSpraakTolk = (fnr: string) =>
+	useFetch<TilrettelagtKommunikasjonData>(`/veilarbperson/api/v2/person/tolk?fnr=${fnr}`, headers);
 
 export const useFetchInnsatsbehov = (fnr: string) =>
 	useFetch<Innsatsbehov>(`/veilarbvedtaksstotte/api/innsatsbehov?fnr=${fnr}`, headers);


### PR DESCRIPTION
Fjerner kallet til `/veilarbjobbsokerkompetanse/api/hent` og setter lamellen til alltid å vise "ingen data tilgjengelig" (som den egentlig har gjort i to måneder alt)