### PR TITLE
Fikser og forenkler toggle for Personalia-lamellen

### DIFF
--- a/src/components/paneler/paneler.tsx
+++ b/src/components/paneler/paneler.tsx
@@ -16,7 +16,7 @@ import { hasHashParam, hasQueryParam } from '../../utils';
 import { TilretteleggingsbehovSpa, TilretteleggingsbehovViewType } from '../tilretteleggingsbehov-spa';
 import './paneler.less';
 import Show from '../felles/show';
-import { PERSONALIA_DATA_FRA_PDL, PERSONALIA_DATA_FRA_TPS } from '../../rest/datatyper/feature';
+import { PERSONALIA_DATA_FRA_TPS } from '../../rest/datatyper/feature';
 
 export const Paneler = () => {
 	const { fnr, features } = useAppStore();
@@ -52,7 +52,7 @@ export const Paneler = () => {
 				</Panel>
 			</Show>
 
-			<Show if={features[PERSONALIA_DATA_FRA_PDL]}>
+			<Show if={!features[PERSONALIA_DATA_FRA_TPS]}>
 				<Panel name="personaliaFraPdl" tittel="Personalia">
 					<PersonaliaV2PanelInnhold />
 				</Panel>

--- a/src/mock/api/veilarbpersonflatefs.ts
+++ b/src/mock/api/veilarbpersonflatefs.ts
@@ -2,14 +2,12 @@ import { rest } from 'msw';
 import { RequestHandlersList } from 'msw/lib/types/setupWorker/glossary';
 import {
 	Features,
-	PERSONALIA_DATA_FRA_PDL,
 	PERSONALIA_DATA_FRA_TPS,
 	SPOR_OM_TILBAKEMELDING,
 	INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE
 } from '../../rest/datatyper/feature';
 
 const features: Features = {
-	[PERSONALIA_DATA_FRA_PDL]: true,
 	[PERSONALIA_DATA_FRA_TPS]: false,
 	[SPOR_OM_TILBAKEMELDING]: true,
 	[INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE]: false

--- a/src/rest/datatyper/feature.ts
+++ b/src/rest/datatyper/feature.ts
@@ -1,17 +1,14 @@
-export const PERSONALIA_DATA_FRA_PDL = 'veilarbmaofs.personalia.pdl.persondata';
 export const PERSONALIA_DATA_FRA_TPS = 'veilarbmaofs.personalia.tps.persondata';
 export const SPOR_OM_TILBAKEMELDING = 'veilarbmaofs.spor.om.tilbakemelding';
 export const INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE = 'veilarbmaofs.hent_innsatsgruppe_og_hovedmal_fra_vedtaksstotte';
 
 export const TOGGLES = [
-	PERSONALIA_DATA_FRA_PDL,
 	PERSONALIA_DATA_FRA_TPS,
 	SPOR_OM_TILBAKEMELDING,
 	INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE
 ];
 
 export interface Features {
-	[PERSONALIA_DATA_FRA_PDL]: boolean;
 	[PERSONALIA_DATA_FRA_TPS]: boolean;
 	[SPOR_OM_TILBAKEMELDING]: boolean;
 	[INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE]: boolean;
@@ -19,7 +16,6 @@ export interface Features {
 
 export const initialFeatures: Features =
 	{
-		[PERSONALIA_DATA_FRA_PDL]: false,
 		[PERSONALIA_DATA_FRA_TPS]: false,
 		[SPOR_OM_TILBAKEMELDING]: false,
 		[INNSATSGRUPPE_OG_HOVEDMAL_FRA_VEDTAKSSTOTTE]: false


### PR DESCRIPTION
Siden det er en toggle for visning fra TPS og en for visning fra PDL viser ingen dersom Unleash er utilgjengelig. Forenkler til å bare ha toggle for TPS, og dermed vil PDL være standard også dersom Unleash er utilgjengelig.