### PR TITLE
Endre API-endepunkt for siste-14a-vedtak

### DIFF
--- a/src/components/paneler/innhold/oppfolging/oppfolging-panel-innhold.tsx
+++ b/src/components/paneler/innhold/oppfolging/oppfolging-panel-innhold.tsx
@@ -5,7 +5,7 @@ import Grid from '../../../felles/grid';
 import { useAppStore } from '../../../../stores/app-store';
 import {
 	fetchTilgorerBrukerUtrulletKontorForVedtaksstotte,
-	fetchInnsatsbehov,
+	fetchSiste14aVedtak,
 	fetchOppfolgingsstatus,
 	fetchPersonaliaV2,
 	fetchVeileder
@@ -21,7 +21,7 @@ import {
 } from '../../../../utils/text-mapper';
 import { erInnsatsgruppe } from '../../../../utils/arena-status-utils';
 import { OrNothing } from '../../../../utils/felles-typer';
-import { Hovedmal, Innsatsbehov, Innsatsgruppe } from '../../../../rest/datatyper/innsatsbehov';
+import { Hovedmal, Siste14aVedtak, Innsatsgruppe } from '../../../../rest/datatyper/siste14aVedtak';
 import {
 	ArenaHovedmalKode,
 	ArenaServicegruppeKode,
@@ -41,7 +41,7 @@ const OppfolgingPanelInnhold = () => {
 
 	const oppfolgingsstatus = usePromise<AxiosResponse<OppfolgingsstatusData>>(() => fetchOppfolgingsstatus(fnr));
 	const personalia = usePromise<AxiosResponse<PersonaliaV2Info>>(() => fetchPersonaliaV2(fnr));
-	const innsatsbehov = usePromise<AxiosResponse<Innsatsbehov>>(() => fetchInnsatsbehov(fnr));
+	const siste14aVedtak = usePromise<AxiosResponse<Siste14aVedtak>>(() => fetchSiste14aVedtak(fnr));
 	const veilederId = isResolved(oppfolgingsstatus) ? oppfolgingsstatus.result.data.veilederId : null;
 	const [veileder, setVeileder] = useState<AxiosResponse<VeilederData> | null>(null);
 	const tilhorerBrukerUtrulletKontorForVedtaksstotte = usePromise<AxiosResponse<VeilederData>>(() =>
@@ -58,13 +58,13 @@ const OppfolgingPanelInnhold = () => {
 		// eslint-disable-next-line
 	}, [oppfolgingsstatus.status]);
 
-	if (isPending(oppfolgingsstatus) || isPending(personalia) || isPending(innsatsbehov)) {
+	if (isPending(oppfolgingsstatus) || isPending(personalia) || isPending(siste14aVedtak)) {
 		return <Laster midtstilt={true} />;
 	}
 
 	const veilederData = veileder ? veileder.data : null;
 	const personaliaData = isResolved(personalia) ? personalia.result.data : null;
-	const innsatsbehovData = isResolved(innsatsbehov) ? innsatsbehov.result.data : null;
+	const siste14aVedtakData = isResolved(siste14aVedtak) ? siste14aVedtak.result.data : null;
 	const oppfolgingsstatusData = isResolved(oppfolgingsstatus) ? oppfolgingsstatus.result.data : null;
 
 	let servicegruppe: OrNothing<ArenaServicegruppeKode> = oppfolgingsstatusData?.servicegruppe;
@@ -76,8 +76,8 @@ const OppfolgingPanelInnhold = () => {
 		// fra vedtaksstøtte dersom det er togglet på. Hvis servicegruppe fra Arena er en innsatsgruppe, så viser vi
 		// innsatsgruppe + hovedmål fra vedtaksstøtte. Hvis servicegruppe fra Arena ikke er en innsatsgruppe, så viser
 		// vi ikke innsatsgruppe og hovedmål fra vedtaksstøtte, siden bruker da har fått en nyere status i Arena.
-		innsatsgruppe = innsatsbehovData?.innsatsgruppe;
-		hovedmal = innsatsbehovData?.hovedmal;
+		innsatsgruppe = siste14aVedtakData?.innsatsgruppe;
+		hovedmal = siste14aVedtakData?.hovedmal;
 	}
 
 	function hentInnsatsgruppeOgHovedmalFraVedtaksstotte() {

--- a/src/components/paneler/innhold/ytelser/ytelser-panel-innhold.tsx
+++ b/src/components/paneler/innhold/ytelser/ytelser-panel-innhold.tsx
@@ -4,12 +4,11 @@ import Grid from '../../../felles/grid';
 import Vedtaksliste from './vedtaksliste';
 import { VedtakType, YtelseData } from '../../../../rest/datatyper/ytelse';
 import { VEDTAKSSTATUSER } from '../../../../utils/konstanter';
-import { fetchInnsatsbehov, fetchOppfolgingsstatus, fetchYtelser } from '../../../../rest/api';
+import { fetchOppfolgingsstatus, fetchYtelser } from '../../../../rest/api';
 import { Feilmelding, Laster, NoData } from '../../../felles/fetch';
 import { isNotStartedOrPending, isRejected, isResolved, usePromise } from '../../../../utils/use-promise';
 import { AxiosResponse } from 'axios';
 import { OppfolgingsstatusData } from '../../../../rest/datatyper/oppfolgingsstatus';
-import { Innsatsbehov } from '../../../../rest/datatyper/innsatsbehov';
 
 const getVedtakForVisning = (vedtaksliste: VedtakType[]) => {
 	return vedtaksliste.filter(vedtak => vedtak.status === VEDTAKSSTATUSER.iverksatt);
@@ -19,13 +18,8 @@ const YtelserPanelInnhold = () => {
 	const { fnr } = useAppStore();
 	const ytelser = usePromise<AxiosResponse<YtelseData>>(() => fetchYtelser(fnr));
 	const oppfolgingsstatus = usePromise<AxiosResponse<OppfolgingsstatusData>>(() => fetchOppfolgingsstatus(fnr));
-	const innsatsbehov = usePromise<AxiosResponse<Innsatsbehov>>(() => fetchInnsatsbehov(fnr));
 
-	if (
-		isNotStartedOrPending(ytelser) ||
-		isNotStartedOrPending(innsatsbehov) ||
-		isNotStartedOrPending(oppfolgingsstatus)
-	) {
+	if (isNotStartedOrPending(ytelser) || isNotStartedOrPending(oppfolgingsstatus)) {
 		return <Laster midtstilt={true} />;
 	} else if (isRejected(ytelser)) {
 		return <Feilmelding />;

--- a/src/mock/api/veilarbvedtaksstotte.ts
+++ b/src/mock/api/veilarbvedtaksstotte.ts
@@ -1,8 +1,8 @@
 import { RequestHandler } from 'msw';
 import { rest } from 'msw';
-import { Hovedmal, Innsatsbehov, Innsatsgruppe } from '../../rest/datatyper/innsatsbehov';
+import { Hovedmal, Siste14aVedtak, Innsatsgruppe } from '../../rest/datatyper/siste14aVedtak';
 
-const innsatsbehov: Innsatsbehov = {
+const siste14aVedtak: Siste14aVedtak = {
 	innsatsgruppe: Innsatsgruppe.STANDARD_INNSATS,
 	hovedmal: Hovedmal.BEHOLDE_ARBEID
 };
@@ -10,8 +10,8 @@ const innsatsbehov: Innsatsbehov = {
 const tilhorerBrukerUtrulletKontor = false;
 
 export const veilarbvedtaksstotteHandlers: RequestHandler[] = [
-	rest.get('/veilarbvedtaksstotte/api/innsatsbehov', (req, res, ctx) => {
-		return res(ctx.delay(500), ctx.json(innsatsbehov));
+	rest.get('/veilarbvedtaksstotte/api/siste-14a-vedtak', (req, res, ctx) => {
+		return res(ctx.delay(500), ctx.json(siste14aVedtak));
 	}),
 
 	rest.get('/veilarbvedtaksstotte/api/utrulling/tilhorerBrukerUtrulletKontor', (req, res, ctx) => {

--- a/src/rest/api.ts
+++ b/src/rest/api.ts
@@ -43,8 +43,8 @@ export const fetchSpraakTolk = (fnr: string) => {
 	return axiosInstance.get(`/veilarbperson/api/v2/person/tolk?fnr=${fnr}`);
 };
 
-export const fetchInnsatsbehov = (fnr: string) => {
-	return axiosInstance.get(`/veilarbvedtaksstotte/api/innsatsbehov?fnr=${fnr}`);
+export const fetchSiste14aVedtak = (fnr: string) => {
+	return axiosInstance.get(`/veilarbvedtaksstotte/api/siste-14a-vedtak?fnr=${fnr}`);
 };
 
 export const fetchFeatureToggle = () => {

--- a/src/rest/datatyper/siste14aVedtak.ts
+++ b/src/rest/datatyper/siste14aVedtak.ts
@@ -1,4 +1,4 @@
-export interface Innsatsbehov {
+export interface Siste14aVedtak {
 	innsatsgruppe: Innsatsgruppe;
 	hovedmal?: Hovedmal;
 }

--- a/src/utils/text-mapper.ts
+++ b/src/utils/text-mapper.ts
@@ -1,4 +1,4 @@
-import { Hovedmal, Innsatsgruppe } from '../rest/datatyper/innsatsbehov';
+import { Hovedmal, Innsatsgruppe } from '../rest/datatyper/siste14aVedtak';
 import EMDASH from './emdash';
 import { ArenaHovedmalKode, OppfolgingsstatusData, ArenaServicegruppeKode } from '../rest/datatyper/oppfolgingsstatus';
 import { OrNothing, StringOrNothing } from './felles-typer';


### PR DESCRIPTION
Endrer også begrep fra innsatsbehov til siste 14a vedtak for å gjenspeile at det ikke nødvendigvis er det gjeldende innsatsbehovet, bare det siste 14a vedtaket.