### PR TITLE
Revert "Tc-258 Formater alle telefonnumre som xxx xx xxx"

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -188,7 +188,9 @@ export function formaterTelefonnummer(landkode: StringOrNothing, telefonnummer: 
 
 	if (utenSpace.length !== 8) {
 		return telefonnummer;
-	} else {
+	} else if (utenSpace.substring(0, 3) === '800') {
 		return formatertLandkode + formatNumber('### ## ###', utenSpace);
+	} else {
+		return formatertLandkode + formatNumber('## ## ## ##', utenSpace);
 	}
 }


### PR DESCRIPTION
Reverts navikt/veilarbmaofs#318
Årsaken er at innemelder i [FAGSYSTEM-239759](https://jira.adeo.no/browse/FAGSYSTEM-239759) bruker iPhone, som tilsynelatende ikke er oppdatert med norsk formatering av telefonnummer. Vi følger [Språkrådet og nummerforskriften](https://www.sprakradet.no/sprakhjelp/Skriveregler/Dato/#tlf).